### PR TITLE
Remove warnings about FanEntity for TURN_ON and TURN_OFF

### DIFF
--- a/custom_components/bambu_lab/fan.py
+++ b/custom_components/bambu_lab/fan.py
@@ -75,7 +75,10 @@ class BambuLabFan(BambuLabEntity, FanEntity):
         """Initialize the fan."""
         self.entity_description = description
         self._attr_unique_id = f"{config_entry.data['serial']}_{description.key}"
-        self._attr_supported_features = FanEntityFeature.SET_SPEED
+        self._attr_supported_features = (
+            FanEntityFeature.SET_SPEED  
+            | FanEntityFeature.TURN_ON  
+            | FanEntityFeature.TURN_OFF)
 
         super().__init__(coordinator=coordinator)
 


### PR DESCRIPTION
Fix:
(<class 'custom_components.bambu_lab.fan.BambuLabFan'>) does not set FanEntityFeature.TURN_ON but implements the turn_on method (<class 'custom_components.bambu_lab.fan.BambuLabFan'>) does not set FanEntityFeature.TURN_OFF but implements the turn_off method